### PR TITLE
Feat: 시작,끝 메시지 받으면 실시간 위치 데이터 웹에 전송 구현

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -3,11 +3,13 @@ import * as Location from "expo-location";
 import { Alert } from "react-native";
 import { useRef } from "react";
 import useLocationPermission from "@/hooks/useLocationPermission";
+import useTracking from "@/hooks/useTracking";
 
 export default function TabTwoScreen() {
   const webViewRef = useRef<WebView>(null);
 
   const { checkLocation, requestPermissions } = useLocationPermission();
+  const { startTracking, stopTracking } = useTracking({ webViewRef });
 
   const getLocation = async () => {
     try {
@@ -32,6 +34,15 @@ export default function TabTwoScreen() {
         if (!permissionsGranted) return;
 
         getLocation();
+        break;
+      }
+      case "START_TRACKING": {
+        startTracking();
+        break;
+      }
+      case "STOP_TRACKING": {
+        stopTracking();
+        break;
       }
     }
   };

--- a/hooks/useTracking.tsx
+++ b/hooks/useTracking.tsx
@@ -1,0 +1,44 @@
+import { useRef } from "react";
+import WebView from "react-native-webview";
+import * as Location from "expo-location";
+import { Alert } from "react-native";
+
+interface Props {
+  webViewRef: React.RefObject<WebView>;
+}
+
+const useTracking = ({ webViewRef }: Props) => {
+  const watchPositionRef = useRef<Location.LocationSubscription | null>(null);
+
+  const startTracking = async () => {
+    try {
+      const watchPostion = await Location.watchPositionAsync(
+        {
+          distanceInterval: 1,
+        },
+        (location) => {
+          const { latitude, longitude } = location.coords;
+          webViewRef.current?.postMessage(
+            JSON.stringify({ latitude, longitude })
+          );
+        }
+      );
+      watchPositionRef.current = watchPostion;
+    } catch {
+      Alert.alert("실시간 위치 정보를 불러오는데 실패하였습니다.");
+    }
+  };
+
+  const stopTracking = () => {
+    if (watchPositionRef.current) {
+      Alert.alert("산책이 종료되었습니다.");
+      watchPositionRef.current.remove();
+    } else {
+      Alert.alert("위치 추적이 활성화되지 않았습니다.");
+    }
+  };
+
+  return { startTracking, stopTracking };
+};
+
+export default useTracking;


### PR DESCRIPTION
## 🔧 작업 내용

웹으로 부터 시작,끝 메시지를 받았을 때 실시간 위치 데이터를 웹으로 전송하였습니다.

## 🔎 작업 중 특이사항 및 정리사항

- 메시지 case에 따라 시작,끝 받으면 Location.watchPostion()으로 실시간으로 위치 전송하기
- 끝나면 remove()로 중지

## 📄 레퍼런스
